### PR TITLE
Makefile: disable CGO in package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: build
 
 # Package lambda function in zip file
 package:
-	docker run -i --rm -v `pwd`:/go/src/github.com/mozilla-services/cloudtrail-streamer \
+	docker run -i --rm -v `pwd`:/go/src/github.com/mozilla-services/cloudtrail-streamer -e CGO_ENABLED=0\
 		golang:1.10 \
 		/bin/bash -c 'cd /go/src/github.com/mozilla-services/cloudtrail-streamer && make docker_build'
 


### PR DESCRIPTION
fixes an issue with `make package`:

```
make package
docker run -i --rm -v `pwd`:/go/src/github.com/mozilla-services/cloudtrail-streamer \
		golang:1.10 \
		/bin/bash -c 'cd /go/src/github.com/mozilla-services/cloudtrail-streamer && make docker_build'
rm -f cloudtrail-streamer cloudtrail-streamer.zip
go get -u golang.org/x/vgo
vgo build -ldflags="-s -w" -o cloudtrail-streamer
go: finding github.com/go-ini/ini v1.38.1
go: finding github.com/aws/aws-lambda-go v1.2.0
go: finding github.com/aws/aws-sdk-go v1.14.32
go: finding github.com/sirupsen/logrus v1.0.6
go: finding github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
go: finding go.mozilla.org/mozlogrus v1.0.0
go: finding go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403
go: finding golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8
go: finding golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
go: finding github.com/go-ini/ini v1.25.4
go: finding github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
go: downloading github.com/aws/aws-lambda-go v1.2.0
go: downloading go.mozilla.org/mozlogrus v1.0.0
go: downloading github.com/sirupsen/logrus v1.0.6
go: downloading github.com/aws/aws-sdk-go v1.14.32
go: downloading go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403
go: downloading golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
go: downloading golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8
go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
go: downloading github.com/go-ini/ini v1.38.1
# runtime/cgo
exec: "clang": executable file not found in $PATH
make: *** [build] Error 2
Makefile:35: recipe for target 'build' failed
make: *** [package] Error 2
```