### PR TITLE
Add support for event filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ The number of records in a batched put to the Kinesis stream.
 
 By default, `CT_KINESIS_BATCH_SIZE` is set to `500` (which is the max allowed).
 
+#### CT_EVENT_FILTERS (optional)
+
+Comma-separated list of `eventSource:eventName` that will be filtered out.
+
+Example: `CT_EVENT_FILTERS="kinesis:DescribeStream,elasticmapreduce:ListClusters"`
+
 ## References
 
 The structure of this project is based off of this AWS tutorial:

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/mozilla-services/cloudtrail-streamer
 require (
 	github.com/aws/aws-lambda-go v1.2.0
 	github.com/aws/aws-sdk-go v1.15.7
-	github.com/go-ini/ini v1.38.1
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+	github.com/go-ini/ini v1.38.1 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/sirupsen/logrus v1.0.6
-	go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403
+	go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403 // indirect
 	go.mozilla.org/mozlogrus v1.0.0
-	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
-	golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8
+	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb // indirect
+	golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -48,6 +49,8 @@ type Config struct {
 
 	awsKinesisClient *kinesis.Kinesis
 	awsSession       *session.Session
+
+	eventFilters []*EventFilter
 }
 
 func (c *Config) init() error {
@@ -93,11 +96,47 @@ func (c *Config) init() error {
 		aws.NewConfig().WithRegion(c.awsKinesisRegion),
 	)
 
+	filters := os.Getenv("CT_EVENT_FILTERS")
+	if filters != "" {
+		c.eventFilters = parseFilters(filters)
+	}
+
 	return nil
 }
 
 type CloudTrailFile struct {
 	Records []map[string]interface{} `json:"Records"`
+}
+
+type EventFilter struct {
+	EventName   string
+	EventSource string
+}
+
+func parseFilters(filters string) []*EventFilter {
+	var eventFilters []*EventFilter
+	for _, filter := range strings.Split(filters, ",") {
+		event_filter := strings.Split(filter, ":")
+		eventFilters = append(eventFilters, newEventFilter(event_filter[0], event_filter[1]))
+	}
+	return eventFilters
+}
+
+func newEventFilter(source, name string) *EventFilter {
+	return &EventFilter{EventName: name, EventSource: fmt.Sprintf("%s.amazonaws.com", source)}
+}
+
+func (ef *EventFilter) DoesMatch(record map[string]interface{}) bool {
+	return record["eventName"] == ef.EventName || record["eventSource"] == ef.EventSource
+}
+
+func doFiltersMatch(record map[string]interface{}) bool {
+	for _, ef := range globalConfig.eventFilters {
+		if ef.DoesMatch(record) {
+			return true
+		}
+	}
+	return false
 }
 
 func fetchLogFromS3(s3Client *s3.S3, bucket string, objectKey string) (*s3.GetObjectOutput, error) {
@@ -156,6 +195,10 @@ func putRecordsToKinesis(logfile *CloudTrailFile) error {
 	var kRecordsBuf []*kinesis.PutRecordsRequestEntry
 
 	for _, record := range logfile.Records {
+		if doFiltersMatch(record) {
+			continue
+		}
+
 		log.Debugf("Writing record to kinesis: %v", record)
 		encodedRecord, err := json.Marshal(record)
 		if err != nil {
@@ -266,6 +309,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config (%v): %s", globalConfig, err)
 	}
+
+	log.Debugf("Running with filters: %v", globalConfig.eventFilters)
 
 	if globalConfig.eventType == "S3" {
 		log.Debug("Starting S3Handler")

--- a/main.go
+++ b/main.go
@@ -117,6 +117,9 @@ func parseFilters(filters string) []*EventFilter {
 	var eventFilters []*EventFilter
 	for _, filter := range strings.Split(filters, ",") {
 		event_filter := strings.Split(filter, ":")
+		if len(event_filter) != 2 {
+			continue
+		}
 		eventFilters = append(eventFilters, newEventFilter(event_filter[0], event_filter[1]))
 	}
 	return eventFilters

--- a/main_test.go
+++ b/main_test.go
@@ -58,6 +58,7 @@ func TestReadLogFile(t *testing.T) {
 }
 
 var testFilters = "kinesis:DescribeStream,elasticmapreduce:ListClusters"
+var testBadFilters = "kinesisDescribeStream,foo:bar:,elasticmapreduce:ListClusters"
 
 func TestParseFilters(t *testing.T) {
 	eventFilters := parseFilters(testFilters)
@@ -65,8 +66,21 @@ func TestParseFilters(t *testing.T) {
 	if len(eventFilters) != 2 {
 		t.Fatal("Parsing erroring, len(eventFilters) != 2")
 	}
-
 	if eventFilters[0].EventSource != "kinesis.amazonaws.com" {
 		t.Fatal("Parsing error, eventFilters[0].EventSource != kinesis.amazonaws.com")
+	}
+
+	eventFiltersWithBad := parseFilters(testBadFilters)
+
+	if len(eventFiltersWithBad) != 1 {
+		t.Fatal("Parsing erroring, len(eventFiltersWithBad) != 1")
+	}
+
+	if eventFiltersWithBad[0].EventSource != "elasticmapreduce.amazonaws.com" {
+		t.Fatal("Parsing error, eventFiltersWithBad[0].EventSource != elasticmapreduce.amazonaws.com")
+	}
+
+	if eventFiltersWithBad[0].EventName != "ListClusters" {
+		t.Fatal("Parsing error, eventFiltersWithBad[0].EventName != ListClusters")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -56,3 +56,17 @@ func TestReadLogFile(t *testing.T) {
 		t.Fatal("Incorrectly parsed record.")
 	}
 }
+
+var testFilters = "kinesis:DescribeStream,elasticmapreduce:ListClusters"
+
+func TestParseFilters(t *testing.T) {
+	eventFilters := parseFilters(testFilters)
+
+	if len(eventFilters) != 2 {
+		t.Fatal("Parsing erroring, len(eventFilters) != 2")
+	}
+
+	if eventFilters[0].EventSource != "kinesis.amazonaws.com" {
+		t.Fatal("Parsing error, eventFilters[0].EventSource != kinesis.amazonaws.com")
+	}
+}


### PR DESCRIPTION
This adds support for event filters, which are used to drop specific
events and not send them to kinesis.

(Also updates `go.mod` with new vgo changes)